### PR TITLE
Uninstall brew packages to fix macOS build

### DIFF
--- a/.github/workflows/build_conan_caches.yml
+++ b/.github/workflows/build_conan_caches.yml
@@ -91,6 +91,11 @@ jobs:
             libxcb-present-dev libxcb-composite0-dev libxcb-ewmh-dev libxcb-res0-dev \
             libxcb-util-dev libxcb-util0-dev
 
+      - name: Uninstall brew packages
+        if: runner.os == 'macOS'
+        run: |
+          brew uninstall boost
+
       - name: Install Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build_conan_caches.yml
+++ b/.github/workflows/build_conan_caches.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Uninstall brew packages
         if: runner.os == 'macOS'
         run: |
-          brew uninstall boost
+          brew uninstall asciidoc source-highlight boost
 
       - name: Install Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Adding a build step to remove brew packages that break the macOS build. Currently, the libmysqlclient package won't build if the boost brew package is installed. This change removes the boost brew package and a few packages that depend on boost so that the build succeeds.