### PR TITLE
Avoid downloading full cache save file from previous run.

### DIFF
--- a/.github/workflows/build_conan_caches.yml
+++ b/.github/workflows/build_conan_caches.yml
@@ -186,7 +186,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          pattern: conan-cache-save_*${{ matrix.os.runs_on }}.tgz
+          pattern: conan-cache-save_*_${{ matrix.os.runs_on }}.tgz
           merge-multiple: true
 
       - name: Display structure of downloaded files


### PR DESCRIPTION
This change prevents the merge jobs from accidentally pulling down the artifact it generated from a previous run. Pulling down this artifact on job reruns was causing out of disk space errors and led to unnecessary work.