### PR TITLE
Ubuntu 24 build fixes

### DIFF
--- a/.github/workflows/build_conan_caches.yml
+++ b/.github/workflows/build_conan_caches.yml
@@ -179,7 +179,7 @@ jobs:
             libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
             libxcb-dri3-dev libxcb-cursor-dev libxcb-dri2-0-dev libxcb-dri3-dev \
             libxcb-present-dev libxcb-composite0-dev libxcb-ewmh-dev libxcb-res0-dev \
-            libxcb-util-dev libxcb-util0-dev
+            libxcb-util-dev libxcb-util0-dev libxkbfile-dev uuid-dev
 
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build_conan_caches.yml
+++ b/.github/workflows/build_conan_caches.yml
@@ -40,7 +40,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip' # caching pip dependencies
 
       - name: Generating Package Info
         id: gen_package_info

--- a/.github/workflows/build_conan_caches.yml
+++ b/.github/workflows/build_conan_caches.yml
@@ -89,7 +89,7 @@ jobs:
             libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
             libxcb-dri3-dev libxcb-cursor-dev libxcb-dri2-0-dev libxcb-dri3-dev \
             libxcb-present-dev libxcb-composite0-dev libxcb-ewmh-dev libxcb-res0-dev \
-            libxcb-util-dev libxcb-util0-dev
+            libxcb-util-dev libxcb-util0-dev libxkbfile-dev uuid-dev
 
       - name: Uninstall brew packages
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
             libxcb-dri3-dev libxcb-cursor-dev libxcb-dri2-0-dev libxcb-dri3-dev \
             libxcb-present-dev libxcb-composite0-dev libxcb-ewmh-dev libxcb-res0-dev \
-            libxcb-util-dev libxcb-util0-dev
+            libxcb-util-dev libxcb-util0-dev libxkbfile-dev uuid-dev
 
       - name: Install Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
- Fix missing packages when building on Ubuntu 24.04
- Fix pip cache failure  in get_packages_to_build job.