### PR TITLE
Force openfx-plugin-tools to build with C++11

### DIFF
--- a/recipes/openfx-plugin-tools/all/CMakeLists.txt
+++ b/recipes/openfx-plugin-tools/all/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 project(openfx-plugin-tools CXX)
 
 set(CMAKE_VERBOSE_MAKEFILE on)
+set(CMAKE_CXX_STANDARD 11)
 
 find_package(openfx REQUIRED CONFIG)
 find_package(expat REQUIRED CONFIG)


### PR DESCRIPTION
Fixes build buster caused by compilers that default to C++17. Currently this module uses openfx/1.4.0 which has code constructs that were deprecated in C++17. Forcing the code to build as C++11 allows us to avoid these issues for now.