### PR TITLE
Introducing natron_installer recipe

### DIFF
--- a/.github/workflows/build_conan_caches.yml
+++ b/.github/workflows/build_conan_caches.yml
@@ -106,12 +106,17 @@ jobs:
         run: |
           conan config install -t dir config
 
+
+      - name: Download msys2 package from conan-center-index
+        if: runner.os == 'Windows'
+        run: |
+          conan download -r conancenter "msys2/cci.latest"
+
       - name: Add Natron specific Conan remotes
         run: |
           conan remote remove conancenter
           conan remote add natron_recipes ${{ github.workspace }}
           conan remote add natron_conancenter ${{ github.workspace }}/modules/conan-center-index
-          conan remote add conancenter https://center2.conan.io
 
       - name: Install dependencies
         run: |
@@ -128,6 +133,11 @@ jobs:
       - name: Remove unnecessary files from cache
         run: |
           conan cache clean '*'
+
+      - name: Remove msys2 package from cache
+        if: runner.os == 'Windows'
+        run: |
+          conan remove -c "msys2/*"
 
       - name: Save cache to file
         run: |
@@ -212,8 +222,7 @@ jobs:
           conan remote remove conancenter
           conan remote add natron_recipes ${{ github.workspace }}
           conan remote add natron_conancenter ${{ github.workspace }}/modules/conan-center-index
-          conan remote add conancenter https://center2.conan.io
-
+ 
       - name: Add each package to cache
         run: |
           python3 scripts/restoreConanCacheSaves.py --remove artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
 
     env:
       CONAN_CACHE_FILENAME: 'conan-cache-save_ubuntu-latest.tgz'
+      CONAN_PROFILE: 'linux_default'
+      NATRON_ARTIFACT_FILENAME: 'natron_ubuntu-latest.tar'
+      DEPS_ARTIFACT_FILENAME: 'natron_ubuntu-latest.deps.json'
 
     steps:
       - name: Checkout branch
@@ -34,7 +37,8 @@ jobs:
             libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
             libxcb-dri3-dev libxcb-cursor-dev libxcb-dri2-0-dev libxcb-dri3-dev \
             libxcb-present-dev libxcb-composite0-dev libxcb-ewmh-dev libxcb-res0-dev \
-            libxcb-util-dev libxcb-util0-dev libxkbfile-dev uuid-dev
+            libxcb-util-dev libxcb-util0-dev libxkbfile-dev uuid-dev \
+            libegl-dev libwayland-dev libwayland-client0 libwayland-egl1
 
       - name: Install Python
         uses: actions/setup-python@v5
@@ -65,15 +69,45 @@ jobs:
 
       - name: Build openfx-misc
         run: |
-          conan create -pr:a linux_default recipes/openfx-misc/all --version=master --build=missing
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes/openfx-misc/all --version=master --build=missing
 
       - name: Build Natron
         run: |
-          conan create -pr:a linux_default recipes/natron/all --version=conan_build --build=missing --lockfile-out=linux_conan.lock
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes/natron/all --version=conan_build --build=missing
+
+      - name: Build Natron Installer
+        run: |
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes/natron_installer/all --version=conan_build --build=missing --lockfile-out=linux_conan.lock
 
       - name: Dump New Lockfile
         run: |
           cat linux_conan.lock
+
+      - name: Deploy Natron Installer
+        run: |
+          conan install -pr:a ${{ env.CONAN_PROFILE }} --build=missing --requires=natron_installer/conan_build -d direct_deploy --deployer-folder natron_deploy
+
+          tar -cv -f ${{ env.NATRON_ARTIFACT_FILENAME }} -C natron_deploy/direct_deploy natron_installer
+
+      - name: Find Deps
+        run: |
+          python3 scripts/find_deps.py \
+            --json=${{ env.DEPS_ARTIFACT_FILENAME }} \
+            natron_deploy/direct_deploy/natron_installer/bin/Natron \
+            natron_deploy/direct_deploy/natron_installer/lib \
+            natron_deploy/direct_deploy/natron_installer/lib/Qt/lib
+
+      - name: Upload Natron Deps
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: ${{ env.DEPS_ARTIFACT_FILENAME }}
+          path: ${{ env.DEPS_ARTIFACT_FILENAME }}
+
+      - name: Upload Natron Deployment
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name:  ${{ env.NATRON_ARTIFACT_FILENAME }}
+          path:  ${{ env.NATRON_ARTIFACT_FILENAME }}
 
   win_test:
     name: Test Windows
@@ -82,6 +116,9 @@ jobs:
     env:
       CONAN_BUILD_WORKSPACE: 'D:/cbw'
       CONAN_CACHE_FILENAME: 'conan-cache-save_windows-latest.tgz'
+      CONAN_PROFILE: 'msvc_profile'
+      NATRON_ARTIFACT_FILENAME: 'natron_windows-latest'
+      DEPS_ARTIFACT_FILENAME: 'natron_windows-latest.deps.json'
 
     steps:
       - name: Checkout branch
@@ -109,6 +146,10 @@ jobs:
           conan cache restore ${{ env.CONAN_CACHE_FILENAME }}
           Remove-Item ${{ env.CONAN_CACHE_FILENAME }}
 
+      - name: Download msys2 package from conan-center-index
+        run: |
+          conan download -r conancenter "msys2/cci.latest"
+
       - name: Add Natron specific Conan remotes
         run: |
           conan remote remove conancenter
@@ -118,22 +159,49 @@ jobs:
 
       - name: Build openfx-misc
         run: |
-          conan create -pr:a msvc_profile recipes\openfx-misc\all --version=master --build=missing
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes\openfx-misc\all --version=master --build=missing
 
       - name: Build Natron
         run: |
-          conan create -pr:a msvc_profile recipes\natron\all --version=conan_build --build=missing --lockfile-out=msvc_conan.lock
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes\natron\all --version=conan_build --build=missing
+
+      - name: Build Natron Installer
+        run: |
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes\natron_installer\all --version=conan_build --build=missing --lockfile-out=msvc_conan.lock
 
       - name: Dump New Lockfile
         run: |
           cat msvc_conan.lock
+
+      - name: Deploy Natron Installer
+        run: |
+          conan install -pr:a ${{ env.CONAN_PROFILE }} --build=missing --requires=natron_installer/conan_build -d direct_deploy --deployer-folder natron_deploy
+
+      - name: Find Deps
+        run: |
+          python3 scripts/find_deps.py --json=${{ env.DEPS_ARTIFACT_FILENAME }} natron_deploy\direct_deploy\natron_installer\bin\Natron.exe natron_deploy\direct_deploy\natron_installer\bin natron_deploy\direct_deploy\natron_installer\lib
+
+      - name: Upload Natron Deps
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: ${{ env.DEPS_ARTIFACT_FILENAME }}
+          path: ${{ env.DEPS_ARTIFACT_FILENAME }}
+
+      - name: Upload Natron Deployment
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name:  ${{ env.NATRON_ARTIFACT_FILENAME }}
+          path:  natron_deploy/direct_deploy/natron
 
   macos_test:
     name: Test MacOS (x86_64)
     runs-on: macos-13
 
     env:
-      CONAN_CACHE_FILENAME: 'conan-cache-save_macos-13.tgz'
+      CONAN_CACHE_FILENAME: 'conan-cache-save_macos-13_10.13.tgz'
+      CONAN_PROFILE: 'macos_default'
+      NATRON_ARTIFACT_FILENAME: 'natron_macos13.tar'
+      DEPS_ARTIFACT_FILENAME: 'natron_macos13.deps.json'
 
     steps:
       - name: Checkout branch
@@ -173,15 +241,45 @@ jobs:
 
       - name: Build openfx-misc
         run: |
-          conan create -pr:a macos_default recipes/openfx-misc/all --version=master --build=missing
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes/openfx-misc/all --version=master --build=missing
 
       - name: Build Natron
         run: |
-          conan create -pr:a macos_default recipes/natron/all --version=conan_build --build=missing --lockfile-out=macos_conan.lock
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes/natron/all --version=conan_build --build=missing
+
+      - name: Build Natron Installer
+        run: |
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes/natron_installer/all --version=conan_build --build=missing --lockfile-out=macos_conan.lock
 
       - name: Dump New Lockfile
         run: |
           cat macos_conan.lock
+
+      - name: Deploy Natron Installer
+        run: |
+          conan install -pr:a ${{ env.CONAN_PROFILE }} --build=missing --requires=natron_installer/conan_build -d direct_deploy --deployer-folder natron_deploy
+
+          tar -cv -f ${{ env.NATRON_ARTIFACT_FILENAME }} -C natron_deploy/direct_deploy natron_installer
+
+      - name: Find Deps
+        run: |
+          python3 scripts/find_deps.py \
+            --json=${{ env.DEPS_ARTIFACT_FILENAME }} \
+            natron_deploy/direct_deploy/natron_installer/Natron.app/Contents/MacOS/Natron \
+            natron_deploy/direct_deploy/natron_installer/Natron.app/Contents/Frameworks \
+            natron_deploy/direct_deploy/natron_installer/Natron.app/Contents/Frameworks/Qt/lib
+
+      - name: Upload Natron Deps
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: ${{ env.DEPS_ARTIFACT_FILENAME }}
+          path: ${{ env.DEPS_ARTIFACT_FILENAME }}
+
+      - name: Upload Natron Deployment
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name:  ${{ env.NATRON_ARTIFACT_FILENAME }}
+          path:  ${{ env.NATRON_ARTIFACT_FILENAME }}
 
   macos_arm_test:
     name: Test MacOS (arm64)
@@ -189,6 +287,9 @@ jobs:
 
     env:
       CONAN_CACHE_FILENAME: 'conan-cache-save_macos-14.tgz'
+      CONAN_PROFILE: 'macos_arm_default'
+      NATRON_ARTIFACT_FILENAME: 'natron_macos14.tar'
+      DEPS_ARTIFACT_FILENAME: 'natron_macos14.deps.json'
 
     steps:
       - name: Checkout branch
@@ -228,13 +329,43 @@ jobs:
 
       - name: Build openfx-misc
         run: |
-          conan create -pr:a macos_arm_default recipes/openfx-misc/all --version=master --build=missing
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes/openfx-misc/all --version=master --build=missing
 
       - name: Build Natron
         run: |
-          conan create -pr:a macos_arm_default recipes/natron/all --version=conan_build --build=missing --lockfile-out=macos_arm_conan.lock
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes/natron/all --version=conan_build --build=missing
+
+      - name: Build Natron Installer
+        run: |
+          conan create -pr:a ${{ env.CONAN_PROFILE }} recipes/natron_installer/all --version=conan_build --build=missing --lockfile-out=macos_arm_conan.lock
 
       - name: Dump New Lockfile
         run: |
           cat macos_arm_conan.lock
+
+      - name: Deploy Natron Installer
+        run: |
+          conan install -pr:a ${{ env.CONAN_PROFILE }} --build=missing --requires=natron_installer/conan_build -d direct_deploy --deployer-folder natron_deploy
+
+          tar -cv -f ${{ env.NATRON_ARTIFACT_FILENAME }} -C natron_deploy/direct_deploy natron_installer
+
+      - name: Find Deps
+        run: |
+          python3 scripts/find_deps.py \
+            --json=${{ env.DEPS_ARTIFACT_FILENAME }} \
+            natron_deploy/direct_deploy/natron_installer/Natron.app/Contents/MacOS/Natron \
+            natron_deploy/direct_deploy/natron_installer/Natron.app/Contents/Frameworks \
+            natron_deploy/direct_deploy/natron_installer/Natron.app/Contents/Frameworks/Qt/lib
+
+      - name: Upload Natron Deps
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: ${{ env.DEPS_ARTIFACT_FILENAME }}
+          path: ${{ env.DEPS_ARTIFACT_FILENAME }}
+
+      - name: Upload Natron Deployment
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name:  ${{ env.NATRON_ARTIFACT_FILENAME }}
+          path:  ${{ env.NATRON_ARTIFACT_FILENAME }}
 

--- a/config/profiles/macos_default
+++ b/config/profiles/macos_default
@@ -6,3 +6,4 @@ compiler.cppstd=gnu17
 compiler.libcxx=libc++
 compiler.version=13
 os=Macos
+os.version=10.13

--- a/recipes/natron/all/conanfile.py
+++ b/recipes/natron/all/conanfile.py
@@ -4,6 +4,9 @@ from conan.tools.env import Environment
 from conan.tools.scm import Git
 from conan.tools.files import apply_conandata_patches, export_conandata_patches
 
+import os
+import shutil
+
 class natronRecipe(ConanFile):
     name = "natron"
     package_type = "application"
@@ -60,7 +63,7 @@ class natronRecipe(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
         tc = CMakeToolchain(self)
-        tc.preprocessor_definitions["NATRON_RUN_WITHOUT_PYTHON"] = "1"
+        tc.preprocessor_definitions["NATRON_RUN_WITHOUT_PYTHON"] = 1
         tc.cache_variables["BUILD_USER_NAME"] = ""
         tc.cache_variables["NATRON_SYSTEM_LIBS"] = "ON"
         tc.generate()
@@ -73,6 +76,13 @@ class natronRecipe(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
+
+        if self.settings.os == "Macos":
+            # Move other binaries so they are with the main Natron app binary.
+            for x in ["NatronRenderer", "natron-python"]:
+                src_path = os.path.join(self.package_folder, "bin", x)
+                shutil.move(src_path,
+                    os.path.join(self.package_folder, "bin", "Natron.app", "Contents", "MacOS"))
 
     def package_info(self):
         self.cpp_info.requires = ["qt::qt", "cpython::cpython", "expat::expat", "boost::boost", "cairo::cairo", "glog::glog", "ceres-solver::ceres-solver"]

--- a/recipes/natron/all/patches/conan_build_changes.patch
+++ b/recipes/natron/all/patches/conan_build_changes.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 48dd73e..1154c0c 100644
+index 48dd73e..ea15ff8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -59,11 +59,11 @@ if(WIN32)
@@ -55,12 +55,8 @@ index 48dd73e..1154c0c 100644
  
  #Since in Natron and OpenFX all strings are supposed UTF-8 and that the constructor
  #for QString(const char*) assumes ASCII strings, we may run into troubles
-@@ -134,9 +134,10 @@ if(UNIX AND NOT APPLE)
-     find_package(ECM NO_MODULE)
-     set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${CMAKE_MODULE_PATH})
-     find_package(X11 REQUIRED)
--    find_package(Wayland COMPONENTS Client Egl)
-+    find_package(wayland COMPONENTS client egl)
+@@ -137,6 +137,7 @@ if(UNIX AND NOT APPLE)
+     find_package(Wayland COMPONENTS Client Egl)
  elseif(APPLE)
      enable_language(OBJCXX)
 +    find_package(OPENGL)
@@ -68,7 +64,7 @@ index 48dd73e..1154c0c 100644
      enable_language(RC)
      add_compile_definitions(WINDOWS WIN32 _UNICODE UNICODE NOMINMAX QHTTP_SERVER_STATIC)
 diff --git a/Engine/AppManager.cpp b/Engine/AppManager.cpp
-index 9174556..8694eab 100644
+index 9174556..a1af7d1 100644
 --- a/Engine/AppManager.cpp
 +++ b/Engine/AppManager.cpp
 @@ -139,7 +139,8 @@
@@ -81,7 +77,23 @@ index 9174556..8694eab 100644
  
  #include "AppManagerPrivate.h" // include breakpad after Engine, because it includes /usr/include/AssertMacros.h on OS X which defines a check(x) macro, which conflicts with boost
  
-@@ -3051,10 +3052,10 @@ PyObject* PyInit_NatronEngine();
+@@ -743,6 +744,7 @@ AppManager::loadInternal(const CLArgs& cl)
+ 
+     _imp->declareSettingsToPython();
+ 
++#ifndef NATRON_RUN_WITHOUT_PYTHON
+     // executeCommandLineSettingCommands
+     {
+         const std::list<std::string>& commands = cl.getSettingCommands();
+@@ -767,6 +769,7 @@ AppManager::loadInternal(const CLArgs& cl)
+             }
+         }
+     }
++#endif  // NATRON_RUN_WITHOUT_PYTHON
+ 
+     ///basically show a splashScreen load fonts etc...
+     return initGui(cl);
+@@ -3051,10 +3054,10 @@ PyObject* PyInit_NatronEngine();
  void
  AppManager::initBuiltinPythonModules()
  {
@@ -97,7 +109,7 @@ index 9174556..8694eab 100644
  
  void
 diff --git a/Engine/CMakeLists.txt b/Engine/CMakeLists.txt
-index 576f7b2..bc8e225 100644
+index 576f7b2..bc99c3f 100644
 --- a/Engine/CMakeLists.txt
 +++ b/Engine/CMakeLists.txt
 @@ -17,9 +17,8 @@
@@ -112,7 +124,22 @@ index 576f7b2..bc8e225 100644
  
  file(GLOB NatronEngine_HEADERS *.h)
  file(GLOB NatronEngine_SOURCES *.cpp)
-@@ -58,7 +57,7 @@ endif()
+@@ -50,7 +49,13 @@ add_custom_command(OUTPUT ${PyEngine_SOURCES}
+ if(UNIX AND NOT APPLE)
+     set(XDG_LIBS ${X11_LIBRARIES})
+     if(Wayland_FOUND)
+-        set(XDG_LIBS Wayland::Client Wayland::Egl ${XDG_LIBS})
++        if (TARGET wayland::wayland-client)
++            # Older target names used on Ubuntu 22.04
++            set(XDG_LIBS wayland::wayland-client wayland::wayland-egl ${XDG_LIBS})
++        else()
++            # Newer target names used on Ubuntu 24.04
++            set(XDG_LIBS Wayland::Client Wayland::Egl ${XDG_LIBS})
++        endif()
+         set(XDG_DEFS __NATRON_WAYLAND__)
+     endif()
+ endif()
+@@ -58,7 +63,7 @@ endif()
  
  list(APPEND NatronEngine_SOURCES
      ${NatronEngine_SOURCES}
@@ -121,7 +148,7 @@ index 576f7b2..bc8e225 100644
      ../Global/glad_source.c
      ../Global/FStreamsSupport.cpp
      ../Global/ProcInfo.cpp
-@@ -72,13 +71,13 @@ target_link_libraries(NatronEngine
+@@ -72,13 +77,13 @@ target_link_libraries(NatronEngine
          HostSupport
          Boost::headers
          Boost::serialization
@@ -141,7 +168,7 @@ index 576f7b2..bc8e225 100644
          Python3::Module
          ${XDG_LIBS}
          ceres
-@@ -93,6 +92,10 @@ if(WIN32)
+@@ -93,6 +98,10 @@ if(WIN32)
      target_link_libraries(NatronEngine PRIVATE mpr)
  endif()
  
@@ -152,6 +179,20 @@ index 576f7b2..bc8e225 100644
  target_include_directories(NatronEngine
      PUBLIC
          ../Global/glad$<IF:$<CONFIG:Debug>,Deb,Rel>/include
+diff --git a/Engine/Knob.cpp b/Engine/Knob.cpp
+index 48e5bd3..0b96f94 100644
+--- a/Engine/Knob.cpp
++++ b/Engine/Knob.cpp
+@@ -2947,7 +2947,9 @@ void
+ KnobHelper::clearExpression(int dimension,
+                             bool clearResults)
+ {
++#ifndef NATRON_RUN_WITHOUT_PYTHON
+     PythonGILLocker pgl;
++#endif  // NATRON_RUN_WITHOUT_PYTHON
+     bool hadExpression;
+     {
+         QMutexLocker k(&_imp->expressionMutex);
 diff --git a/Gui/CMakeLists.txt b/Gui/CMakeLists.txt
 index b3e06b0..381bc9c 100644
 --- a/Gui/CMakeLists.txt

--- a/recipes/natron/all/test_package/conanfile.py
+++ b/recipes/natron/all/test_package/conanfile.py
@@ -11,5 +11,12 @@ class natronTestConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            cmd = "{} -v".format(os.path.join(self.dependencies[self.tested_reference_str].cpp_info.bindirs[0], "NatronRenderer"))
-            self.run(cmd, env="conanrun")
+            package_base = self.dependencies[self.tested_reference_str].package_folder
+            dest_bin_dir = os.path.join(package_base, "bin")
+            if self.settings.os == "Macos":
+                package_base = os.path.join(dest_bin_dir, "Natron.app", "Contents")
+                dest_bin_dir = os.path.join(package_base, "MacOS")
+
+            for binary, version_flag in [("NatronRenderer", "-v"), ("Natron", "-v"), ("natron-python", "--version")]:
+                binary_path = os.path.join(dest_bin_dir, binary)
+                self.run(f"{binary_path} {version_flag}", env="conanrun")

--- a/recipes/natron_installer/all/conanfile.py
+++ b/recipes/natron_installer/all/conanfile.py
@@ -1,0 +1,512 @@
+import os
+import shutil
+from conan import ConanFile
+from conan.tools.files import copy, rm, save
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import VCVars
+from conan.tools.scm import Git, Version
+
+import os.path
+import re
+import shutil
+import io
+import json
+import subprocess
+
+class NatronInstallerConanfile(ConanFile):
+    name = "natron_installer"
+    version = "conan_build"
+    description = "Natron Installer"
+    license = "GPL-2.0-only"
+    homepage = "<Your project homepage goes here>"
+
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+
+    # The requirements method allows you to define the dependencies of your recipe
+    def requirements(self):
+        self.requires(f"natron/{self.version}")
+        self.requires(f"openfx-misc/master")
+
+    def source(self):
+        # TODO: Create a proper package for Natron OCIO configs.
+        git = Git(self, folder="OpenColorIO-Configs")
+        git.fetch_commit(url="https://github.com/NatronGitHub/OpenColorIO-Configs.git",
+                commit="master")
+        git.run("submodule update -i --recursive --depth 1")
+
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def generate(self):
+        if self.settings.os == "Windows":
+            ms = VCVars(self)
+            ms.generate()
+
+    # This method is used to build the source code of the recipe using the desired commands.
+    def build(self):
+        shutil.copytree(
+            os.path.join(self.source_folder, "OpenColorIO-Configs"),
+            os.path.join(self.build_folder, "OpenColorIO-Configs"))
+
+
+    def _fix_rpath(self, directory, rpath_list, recurse=False):
+        base_dir = os.path.join(self.package_folder, directory)
+        dirs_left = [(base_dir, rpath_list)]
+        while len(dirs_left):
+            (current_dir, current_rpath_list) = dirs_left.pop(0)
+            for filename in os.listdir(current_dir):
+                binary_path = os.path.join(current_dir, filename)
+                if os.path.isfile(binary_path):
+                    if self.settings.os == "Linux":
+                        self.output.info(f"Updating RPATH for {binary_path}")
+                        new_rpath = ""
+                        for current_rpath in current_rpath_list:
+                            origin_path = f"/{current_rpath}" if len(current_rpath) > 0 else ""
+                            if len(new_rpath) > 0:
+                                new_rpath += ":"
+                            new_rpath += f"$ORIGIN{origin_path}"
+                        cmd = f'patchelf --force-rpath --set-rpath \'{new_rpath}\' {binary_path}'
+                        self.output.info(f"RPATH command {cmd}")
+                        self.run(cmd)
+                    elif self.settings.os == "Macos" and len(current_rpath_list) > 0:
+                        file_info = subprocess.check_output(["file", "-b", binary_path])
+                        if file_info.decode("utf-8").find("Mach-O") == 0:
+                            self.output.info(f"Updating rpath for {binary_path}")
+                            cmd = 'install_name_tool'
+                            for current_rpath in current_rpath_list:
+                                new_rpath = f"@loader_path/{current_rpath}"
+                                cmd += f' -add_rpath "{new_rpath}"'
+                            cmd +=  f" {binary_path}"
+                            self.run(cmd)
+
+                elif os.path.isdir(binary_path) and recurse:
+                    next_rpath_list = []
+                    for x in current_rpath_list:
+                        next_rpath_list.append(os.path.join("..", x))
+                    dirs_left.append((binary_path, next_rpath_list))
+
+    @property
+    def _deps_lib_dir(self):
+        if self.settings.os == "Windows":
+            # All dependencies need to be in the bin dir next to the executables on Windows
+            # so that we don't have to update PATH environment variable to find them.
+            return os.path.join(self.package_folder, "bin")
+        elif self.settings.os == "Macos":
+            return os.path.join(self.package_folder, "Natron.app", "Contents", "Frameworks")
+
+        return os.path.join(self.package_folder, "lib")
+
+    @property
+    def _qt_base_dir(self):
+        if self.settings.os == "Windows":
+            return self._deps_lib_dir
+
+        return os.path.join(self._deps_lib_dir, "Qt")
+
+    @property
+    def _qt_lib_dir(self):
+        if self.settings.os == "Windows":
+            # Copy all the Qt libraries into the same directory as the other dependencies.
+            return self._deps_lib_dir
+        return os.path.join(self._qt_base_dir, "lib")
+
+    @property
+    def _qt_plugins_dir(self):
+        if self.settings.os == "Windows":
+            # Qt plugins need to be installed in the same directory as the
+            # executable so that Qt does not try to look for them in bin/../plugins
+            return self._deps_lib_dir
+
+        return os.path.join(self._qt_base_dir, "plugins")
+
+    def _copy_dependencies(self):
+        self.output.info("Copying dependencies...")
+        files = []
+        install_name_rewrites = []
+
+        deps_to_process = []
+        deps_already_requested = set()
+
+        # Collect top level dependencies
+        for dep in self.dependencies.host.values():
+            deps_to_process.append(dep)
+            deps_already_requested.add(dep.ref.name)
+
+        while len(deps_to_process) > 0:
+            dep = deps_to_process.pop(0)
+
+            # Collect all of the dependencies of the current dependency being handled
+            # and add only the ones that have not been requested yet to the processing list.
+            for x in dep.dependencies.host.values():
+                if x.ref.name not in deps_already_requested:
+                    deps_to_process.append(x)
+                    deps_already_requested.add(x.ref.name)
+
+            if not dep.package_folder or len(dep.cpp_info.libdirs) == 0:
+                continue
+
+            self.output.info(f"\t{dep.ref.name}")
+
+            src_dir = os.path.join(dep.package_folder, dep.cpp_info.libdirs[0] if self.settings.os != "Windows" else dep.cpp_info.bindirs[0])
+            if not os.path.exists(src_dir):
+                continue
+
+            dst_dir = self._deps_lib_dir
+            if dep.ref.name == "qt":
+                dst_dir = self._qt_lib_dir
+                # Copy Qt plugins. These need to be in "../plugins" relative to the Qt shared libraries.
+                files += copy(self, "*", os.path.join(dep.package_folder, "plugins"),
+                    self._qt_plugins_dir)
+            elif dep.ref.name == "cpython":
+               (python_files, python_install_name_rewrites) = self._copy_python(dep)
+               files += python_files
+               install_name_rewrites += python_install_name_rewrites
+               continue
+
+            files += copy(self, "*.so", src_dir, dst_dir)
+            files += copy(self, "*.so.*", src_dir, dst_dir)
+            files += copy(self, "*.dll", src_dir, dst_dir)
+            files += copy(self, "*.dylib", src_dir, dst_dir)
+
+        return (files, install_name_rewrites)
+
+    def _copy_natron_binaries(self, dst_dir):
+        self.output.info("Copying Natron binaries...")
+        files = []
+
+        natron_package_folder = self.dependencies["natron"].package_folder
+        src_dir = os.path.join(natron_package_folder, "bin")
+        if self.settings.os == "Macos":
+            src_dir = os.path.join(src_dir, "Natron.app", "Contents", "MacOS")
+
+        natron_binaries = ["Natron", "NatronRenderer", "natron-python"]
+
+        for src_binary_filename in natron_binaries:
+            if self.settings.os == "Windows":
+                src_binary_filename += ".exe"
+
+            full_src_binary_path = os.path.join(src_dir, src_binary_filename)
+            full_dst_binary_path = os.path.join(dst_dir, src_binary_filename)
+            files.append(shutil.copy(full_src_binary_path, full_dst_binary_path))
+
+        return files
+
+    def _files_in_dir(self, dir_to_walk):
+        ret = []
+        for root, dirs, files in os.walk(dir_to_walk):
+                for x in files:
+                    ret.append(os.path.join(root, x))
+        return ret
+
+
+    def _copy_plugins(self, plugins_dir):
+        self.output.info("Copying Plugins...")
+        files = []
+
+        natron_plugins_dir = os.path.join(plugins_dir, "OFX", "Natron")
+        plugin_info = {
+            "openfx-misc": ["Misc.ofx.bundle", "CImg.ofx.bundle"]
+        }
+        for (dep_name, dir_list) in plugin_info.items():
+            src_base_dir = self.dependencies[dep_name].package_folder
+            for x in dir_list:
+                dir_copied = shutil.copytree(os.path.join(src_base_dir, x),
+                    os.path.join(natron_plugins_dir, x))
+                files += self._files_in_dir(dir_copied)
+        return files
+
+    def _copy_resources(self, resources_dir):
+        self.output.info("Copying Resources ...")
+        files = []
+
+        dir_copied = shutil.copytree(
+            os.path.join(self.build_folder, "OpenColorIO-Configs"),
+            os.path.join(resources_dir, "OpenColorIO-Configs"))
+        files += self._files_in_dir(dir_copied)
+
+        return files
+
+    def _copy_system_deps(self, dst_dir):
+        files = []
+
+        paths_to_copy = []
+        if self.settings.os == "Macos":
+            if self.settings.arch == "x86_64":
+                paths_to_copy = [
+                    "/usr/local/opt/gettext/lib/libintl.8.dylib",
+                    ]
+
+        for x in paths_to_copy:
+            if not os.path.exists(x):
+                self.output.error(f"{x} does not exist.")
+            elif not os.path.isfile(x):
+                self.output.error(f"{x} is not a file.")
+            else:
+                if os.path.islink(x):
+                    canonical_path = os.path.realpath(x, strict=True)
+                    self.output.info(f"{x} is a symbolic link to {canonical_path}.")
+                    files += copy(self, os.path.basename(canonical_path),
+                        os.path.dirname(canonical_path), dst_dir)
+
+                files += copy(self, os.path.basename(x),
+                    os.path.dirname(x), dst_dir)
+
+        return files
+
+    def _create_framework_dir(self, base_path, name, version, shared_lib_src, info_plist_str):
+        files = []
+        install_name_rewrites = []
+        framework_dir = os.path.join(base_path, f"{name}.framework")
+        versions_dir = os.path.join(framework_dir, "Versions")
+        version_dir = os.path.join(versions_dir, version)
+        current_version_dir = os.path.join(versions_dir, "Current")
+        resources_dir = os.path.join(version_dir, "Resources")
+
+        os.makedirs(resources_dir)
+        files += shutil.copy(shared_lib_src, os.path.join(version_dir, name))
+        install_name_rewrites.append((f"@rpath/{os.path.basename(shared_lib_src)}", f"@rpath/{name}.framework/{name}"))
+        info_plist_path = os.path.join(resources_dir, "Info.plist")
+        save(self, info_plist_path, info_plist_str)
+        files += info_plist_path
+
+        os.symlink(version, current_version_dir)
+        os.symlink(os.path.join("Versions", "Current", "Resources"),
+            os.path.join(framework_dir, "Resources"))
+        os.symlink(os.path.join("Versions", "Current", name),
+            os.path.join(framework_dir, name))
+
+        return (files, install_name_rewrites)
+
+    def _copy_python(self, dep_info):
+        files = []
+        install_name_rewrites = []
+
+        py_version = Version(dep_info.ref.version)
+        py_version_major_minor = f"{py_version.major}.{py_version.minor}"
+        py_dir_name = f"python{py_version_major_minor}"
+
+        shared_lib_src_folder = os.path.join(dep_info.package_folder, "lib")
+        shared_lib_src = None
+        if self.settings.os == "Windows":
+            shared_lib_src = os.path.join(dep_info.package_folder, "bin", f"python{py_version.major}{py_version.minor}.dll")
+        elif self.settings.os == "Linux":
+            shared_lib_src = os.path.join(dep_info.package_folder, "lib", f"lib{py_dir_name}.so.1.0")
+        elif self.settings.os == "Macos":
+            shared_lib_src = os.path.join(dep_info.package_folder, "lib", f"lib{py_dir_name}.dylib")
+        else:
+            raise Exception(f"Can't determine python shared library for {self.settings.os}")
+
+        dst_dir = self._deps_lib_dir
+        if self.settings.os == "Macos":
+            info_plist = f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
+<plist version="0.9">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleExecutable</key>
+    <string>Python</string>
+    <key>CFBundleGetInfoString</key>
+    <string>Python Runtime and Library</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.python.python</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Python</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleShortVersionString</key>
+    <string>{py_version}, (c) 2001-2025 Python Software Foundation.</string>
+    <key>CFBundleLongVersionString</key>
+    <string>{py_version}, (c) 2001-2025 Python Software Foundation.</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleVersion</key>
+    <string>{py_version}</string>
+</dict>
+</plist>
+"""
+            (new_files, new_install_name_rewrites) = self._create_framework_dir(self._deps_lib_dir, "Python", py_version_major_minor, shared_lib_src, info_plist)
+            files += new_files
+            install_name_rewrites += new_install_name_rewrites
+        else:
+            files.append(shutil.copy(shared_lib_src, os.path.join(dst_dir, os.path.basename(shared_lib_src))))
+
+
+        python_lib_dir = os.path.join(self.package_folder, "lib")
+        if self.settings.os == "Macos":
+            python_lib_dir = os.path.join(self._deps_lib_dir, "Python.framework", "Versions", py_version_major_minor, "lib")
+
+        if not os.path.exists(python_lib_dir):
+            os.makedirs(python_lib_dir)
+
+        embed_src_dir = os.path.join(dep_info.package_folder, "lib", py_dir_name) if self.settings.os != "Windows" else os.path.join(dep_info.package_folder, "bin", "Lib")
+        embed_dst_dir = os.path.join(python_lib_dir, py_dir_name)
+        dir_copied = shutil.copytree(embed_src_dir, embed_dst_dir)
+
+        if self.settings.os == "Windows":
+            files += copy(self, "*.pyd",
+                os.path.join(dep_info.package_folder, "bin", "DLLs"),
+                os.path.join(embed_dst_dir, "lib-dynload"))
+
+
+        # Remove all existing pycache files
+        rm(self, "__pycache__", dir_copied, recursive=True)
+
+        files += self._files_in_dir(dir_copied)
+
+        return (files, install_name_rewrites)
+
+    def package(self):
+        files = []
+        install_name_rewrites = []
+
+        if not os.path.exists(self._deps_lib_dir):
+            os.makedirs(self._deps_lib_dir)
+
+
+        package_base = self.package_folder
+        dest_bin_dir = os.path.join(package_base, "bin")
+
+        if self.settings.os == "Macos":
+            package_base = os.path.join(package_base, "Natron.app", "Contents")
+            dest_bin_dir = os.path.join(package_base, "MacOS")
+
+        dest_plugins_dir = os.path.join(package_base, "Plugins")
+        dest_resources_dir = os.path.join(package_base, "Resources")
+
+        for x in [dest_bin_dir, dest_plugins_dir, dest_resources_dir]:
+            if not os.path.exists(x):
+                os.makedirs(x)
+
+        (deps_files, deps_install_name_rewrites) = self._copy_dependencies()
+        files += deps_files
+        install_name_rewrites += deps_install_name_rewrites
+
+        files += self._copy_natron_binaries(dest_bin_dir)
+
+        files += self._copy_plugins(dest_plugins_dir)
+
+        files += self._copy_resources(dest_resources_dir)
+
+        files += self._copy_system_deps(self._deps_lib_dir)
+
+        # Fix rpaths so binaries can find their dependencies.
+        rel_deps_lib = os.path.relpath(self._deps_lib_dir, dest_bin_dir)
+        rel_qt_lib = os.path.relpath(self._qt_lib_dir, dest_bin_dir)
+        paths_for_bin = set()
+        if rel_deps_lib != ".":
+            paths_for_bin.add(rel_deps_lib)
+        if rel_qt_lib != ".":
+            paths_for_bin.add(rel_qt_lib)
+        if len(paths_for_bin) == 0:
+            paths_for_bin.add("")
+
+        self._fix_rpath(os.path.relpath(dest_bin_dir, self.package_folder), list(paths_for_bin), recurse=True)
+
+        if rel_deps_lib != ".":
+            # deps_lib is not the bin directory so fix all the rpaths in that directory as well.
+            self._fix_rpath(os.path.relpath(self._deps_lib_dir, self.package_folder), [""])
+
+        if self.settings.os == "Macos":
+            # Create application plist
+            app_plist = f"""<?xml version=1.0 encoding=UTF-8?>
+<!DOCTYPE plist PUBLIC -//Apple//DTD PLIST 1.0//EN http://www.apple.com/DTDs/PropertyList-1.0.dtd>
+<plist version=1.0>
+<dict>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHighResolutionCapable</key>
+    <string>True</string>
+    <key>CFBundleIconFile</key>
+    <string>natronIcon.icns</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>{self.version}</string>
+    <key>CFBundleVersion</key>
+    <string>{self.version}</string>
+    <key>CFBundleSignature</key>
+    <string>Ntrn</string>
+    <key>CFBundleName</key>
+    <string>Natron</string>
+    <key>CFBundleExecutable</key>
+    <string>Natron</string>
+    <key>CFBundleIdentifier</key>
+    <string>fr.inria.Natron</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>ntp</string>
+            </array>
+            <key>CFBundleTypeMIMETypes</key>
+            <array>
+                <string>application/vnd.natron.project</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>Natron Project File</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>LSIsAppleDefaultForType</key>
+            <true/>
+            <key>CFBundleTypeIconFile</key>
+            <string>natronProjectIcon_osx.icns</string>
+        </dict>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>nps</string>
+            </array>
+            <key>CFBundleTypeMIMETypes</key>
+            <array>
+                <string>application/vnd.natron.nodepresets</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>Natron Node Presets</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleTypeIconFile</key>
+            <string>natronProjectIcon_osx.icns</string>
+        </dict>
+        <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>nl</string>
+            </array>
+            <key>CFBundleTypeMIMETypes</key>
+            <array>
+                <string>application/vnd.natron.layout</string>
+            </array>
+            <key>CFBundleTypeName</key>
+            <string>Natron Layout</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleTypeIconFile</key>
+            <string>natronProjectIcon_osx.icns</string>
+        </dict>
+    </array>
+</dict>
+</plist>"""
+
+            app_plist_filename = os.path.join(package_base, "Info.plist")
+            save(self, app_plist_filename, app_plist)
+            files += app_plist_filename
+
+            # Apply all install name changes.
+            base_cmd = "install_name_tool"
+            for (old_name, new_name) in install_name_rewrites:
+                base_cmd += f" -change '{old_name}' '{new_name}'"
+            for root, dirs, files in os.walk(dest_bin_dir, topdown=False):
+                for x in files:
+                    self.run(f"{base_cmd} {os.path.join(root, x)}")
+
+
+        self.output.info(f"\n\nfiles copied:")
+        for x in files:
+            self.output.info(f"\t{os.path.relpath(x, self.package_folder)}")
+

--- a/recipes/natron_installer/config.yml
+++ b/recipes/natron_installer/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "conan_build":
+    folder: all

--- a/recipes/openfx-misc/all/conanfile.py
+++ b/recipes/openfx-misc/all/conanfile.py
@@ -12,7 +12,7 @@ class openFxMiscRecipe(ConanFile):
     # Optional metadata
     license = "GPL-2.0-only"
     author = "The Natron Developers"
-    url = "https://github.com/acolwell/natron_conan"
+    url = "https://github.com/NatronGitHub/openfx-misc"
     description = "Miscellaneous OFX / OpenFX / Open Effects plugins"
     topics = ("OpenFX", "Natron")
 
@@ -88,7 +88,7 @@ class openFxMiscRecipe(ConanFile):
         plugin_names = ["Misc", "CImg"]
         for plugin_name in plugin_names:
             src_folder = os.path.join(self.build_folder, self._deps_lib_folder)
-            dst_folder = os.path.join(self.package_folder, f"{plugin_name}.ofx.bundle", "Contents", plugin_arch)
+            dst_folder = os.path.join(self.package_folder, f"{plugin_name}.ofx.bundle", "Contents", "Libraries")
             copy(self, "*.dylib", src_folder, dst_folder)
             copy(self, "*.dll", src_folder, dst_folder)
             copy(self, "*.so.*", src_folder, dst_folder)

--- a/scripts/find_deps.py
+++ b/scripts/find_deps.py
@@ -1,0 +1,416 @@
+
+import argparse
+import io
+import os.path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import json
+
+def fix_location(platform, location_path):
+    if platform == "Msys" and location_path[0] == '/':
+        new_location_path = subprocess.run(
+            ["cygpath", "-m", location_path],
+            capture_output=True).stdout.decode("utf-8").strip()
+        return new_location_path
+
+    return location_path
+
+def find_dump_bin():
+    program_files_path = os.environ.get("ProgramFiles(x86)")
+    vswhere_path = os.path.join(program_files_path, "Microsoft Visual Studio", "Installer", "vswhere.exe")
+    if not os.path.exists(vswhere_path) or not os.path.isfile(vswhere_path):
+        return None
+
+    proc = subprocess.Popen([vswhere_path], stdout=subprocess.PIPE)
+    msvc_regex = re.compile("^installationPath:\s+(.+)$")
+    msvs_install_path = None
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            break
+        line = line.decode("utf-8").strip()
+
+        m = msvc_regex.match(line)
+        if m:
+            msvs_install_path = m.group(1)
+            break
+
+    if msvs_install_path == None:
+        return None
+    msvc_base_path = os.path.join(msvs_install_path, "VC", "Tools", "MSVC")
+
+    dump_bin_path = None
+    for root, dirs, files in os.walk(msvc_base_path, topdown=False):
+        if "dumpbin.exe" in files and os.path.basename(root):
+            host_dir = os.path.basename(os.path.dirname(root))
+            target_dir = os.path.basename(root)
+            if host_dir == "Hostx64" and target_dir == "x64":
+                dump_bin_path = os.path.join(root,"dumpbin.exe")
+                break
+
+    return dump_bin_path
+
+def find_dep_in_search_dirs(dep_name):
+    search_dep_location = None
+    for x in search_directories:
+        candidate_dep_location = os.path.join(x, dep_name)
+        if os.path.exists(candidate_dep_location) and os.path.isfile(candidate_dep_location):
+            search_dep_location = candidate_dep_location
+            break
+    return search_dep_location
+
+def is_mac_system_lib(dep_location):
+    mac_system_libs = [
+            "/usr/lib/libSystem.B.dylib",
+            "/usr/lib/libc++.1.dylib",
+            "/usr/lib/libobjc.A.dylib",
+            "/usr/lib/libiconv.2.dylib",
+            "/usr/lib/libresolv.9.dylib",
+        ]
+    return (dep_location.startswith("/System/Library/Framework") or
+            dep_location in mac_system_libs)
+
+def should_follow_dep(platform, dep_name, dep_location):
+    if platform == "Windows":
+        if (dep_name.startswith("api-ms-win-") or
+            dep_name.startswith("ext-ms-win-") or
+            dep_location.startswith("C:\\Windows\\system32")):
+            return False
+    elif platform == "Macos" and is_mac_system_lib(dep_location):
+        return False
+    elif platform == "Linux":
+        linux_system_libs = [
+            "/lib/x86_64-linux-gnu/libGL.so.1",
+            "/lib/x86_64-linux-gnu/libGLX.so.0",
+            "/lib/x86_64-linux-gnu/libGLdispatch.so.0",
+            "/lib/x86_64-linux-gnu/libX11.so.6",
+            "/lib/x86_64-linux-gnu/libXau.so.6",
+            "/lib/x86_64-linux-gnu/libXdmcp.so.6",
+            "/lib/x86_64-linux-gnu/libbsd.so.0",
+            "/lib/x86_64-linux-gnu/libmd.so.0",
+            "/lib/x86_64-linux-gnu/libxcb.so.1",
+         ]
+        if dep_location in linux_system_libs:
+            return False
+    return True
+
+def is_valid_lib_path(platform, dep_location):
+    if os.path.isfile(dep_location):
+        return True
+
+    # MacOS has some library paths that aren't files, but are still valid and handled
+    # by the library loader.
+    if platform == "Macos" and is_mac_system_lib(dep_location):
+        return True
+
+    return False
+
+def get_deps_for_binary(platform, binary_path, search_directories):
+    if platform == "Windows":
+        ret = set()
+        dump_bin_path = find_dump_bin()
+        if dump_bin_path == None:
+            raise Exception("Failed to find dumpbin")
+
+        proc = subprocess.Popen([dump_bin_path, "/dependents", binary_path], stdout=subprocess.PIPE)
+        missing_deps = {}
+        windows_search_paths = os.environ.get("PATH").split(";")
+        while True:
+            line = proc.stdout.readline()
+            if not line:
+                break
+            line = line.decode("utf-8").strip()
+            if re.match("^[\w_-]+.dll$", line.lower().strip()):
+                dep_name = line.strip()
+
+                windows_dep_location = None
+                for base_path in windows_search_paths:
+                    potential_dep_location = os.path.join(base_path, dep_name)
+                    if os.path.exists(potential_dep_location) and os.path.isfile(potential_dep_location):
+                        windows_dep_location = potential_dep_location
+                        break
+
+                if windows_dep_location == None:
+                    missing_deps.setdefault(dep_name, set())
+                else:
+                    ret.add((dep_name, fix_location(platform, windows_dep_location)))
+
+        return (ret, missing_deps)
+    elif platform == "Macos":
+        my_name = os.path.basename(binary_path)
+        ret = set()
+
+        loader_path = os.path.dirname(binary_path)
+        rpaths = []
+        cmd_re = re.compile("^cmd\s+(\S+)$")
+        path_re = re.compile("^path\s+(\S+)\s+\(.+\)$")
+        proc = subprocess.Popen(["otool", "-l", binary_path],stdout=subprocess.PIPE)
+        path_is_rpath = False
+        for line in proc.stdout:
+            line = line.decode("utf-8").strip()
+            m = cmd_re.match(line)
+            if m:
+                path_is_rpath = m.group(1) == "LC_RPATH"
+            else:
+                m = path_re.match(line)
+                if m:
+                    rpaths.append(m.group(1))
+
+        #print("RPATHS ", rpaths)
+        proc = subprocess.Popen(["otool", "-L", binary_path], stdout=subprocess.PIPE)
+        missing_deps = {}
+
+        lib_re = re.compile("^(\S+)\s+\(.+\)$")
+        for line in proc.stdout:
+            line = line.decode("utf-8").strip()
+            m = lib_re.match(line)
+            if m:
+                macos_dep_location = m.group(1)
+                dep_name = os.path.basename(macos_dep_location)
+
+                if dep_name == my_name:
+                    continue
+
+                if macos_dep_location.startswith("@rpath"):
+                    for rpath in rpaths:
+                        if rpath.startswith("@loader_path"):
+                            rpath = rpath.replace("@loader_path", loader_path)
+                        alt_dep_location = macos_dep_location.replace("@rpath", rpath)
+
+                        alt_dep_location = os.path.normpath(alt_dep_location)
+
+                        if os.path.exists(alt_dep_location) and os.path.isfile(alt_dep_location):
+                            macos_dep_location = alt_dep_location
+                            break
+
+                if macos_dep_location == None:
+                    missing_deps.setdefault(dep_name, set())
+                else:
+                    ret.add((dep_name, fix_location(platform, macos_dep_location)))
+
+        return (ret, missing_deps)
+
+    my_name = os.path.basename(binary_path)
+    proc = subprocess.Popen(['ldd', binary_path], stdout=subprocess.PIPE)
+
+    ret = set()
+    missing_deps = {}
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            break
+
+        line = line.decode("utf-8").strip()
+
+        p = re.compile("^([^ ]+) => ([^(]+)( (.*))?$")
+        m = p.match(line)
+        if m:
+            dep_name = m.group(1)
+            ldd_dep_location = m.group(2)
+
+            # Skip self
+            if dep_name == my_name:
+                continue
+
+            if ldd_dep_location == "not found":
+                missing_deps.setdefault(dep_name, set())
+            else:
+                ret.add((dep_name, fix_location(platform, ldd_dep_location)))
+        else:
+            if ("linux-vdso.so.1" in line or
+                "ld-linux-x86-64.so" in line or
+                "statically linked" in line):
+                continue
+            raise Exception(f"Unexpected line in ldd output: {line}")
+    return (ret, missing_deps)
+
+def get_all_deps_for_binary(binary_key_name, json_dict):
+    if  binary_key_name not in json_dict["binary_deps"]:
+        return None
+
+    ret = set()
+    deps_list =  json_dict["binary_deps"][binary_key_name].copy()
+    while len(deps_list) > 0:
+        dep = deps_list.pop()
+        if dep not in ret:
+            ret.add(dep)
+            deps_list += json_dict["binary_deps"][dep]
+    return ret
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <target_binary> [search_directories]")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(
+                    prog='find_and_copy_deps',
+                    description='Finds all the library dependencies of a executable \
+                    or shared library and copies them to a specified directory.')
+    parser.add_argument('--json')
+    parser.add_argument('--depdirs')
+    parser.add_argument('--manifest')
+    parser.add_argument('--output_directory')
+    parser.add_argument('target_binary')
+    parser.add_argument('search_directories', nargs="*", default=[])
+
+    cmd_line_args = parser.parse_args()
+
+    target_binary = cmd_line_args.target_binary
+    output_directory = cmd_line_args.output_directory
+
+    search_directories = []
+    if cmd_line_args.depdirs:
+        if not os.path.isfile(cmd_line_args.depdirs):
+            sys.stderr.write(f"{cmd_line_args.depdirs} is not a file.\n")
+            sys.exit(1)
+
+        with open(cmd_line_args.depdirs, "rb") as file:
+            dep_dirs = json.load(file)
+            if not isinstance(dep_dirs, list):
+                sys.stderr.write(f"{cmd_line_args.depdirs} does not contain a list.\n")
+                sys.exit(1)
+
+            search_directories += dep_dirs
+
+    search_directories += cmd_line_args.search_directories.copy()
+
+    platform = None
+
+    if sys.platform =="win32":
+        platform = "Windows"
+    elif sys.platform == "msys":
+        platform = "Msys"
+    elif sys.platform == "linux":
+        platform = "Linux"
+    elif sys.platform == "darwin":
+        platform = "Macos"
+
+
+    if not os.path.exists(target_binary):
+        sys.stderr.write(f"{target_binary} does not exist.\n")
+        sys.exit(1)
+
+    if not os.path.isfile(target_binary):
+        sys.stderr.write(f"{target_binary} is not a file.\n")
+        sys.exit(1)
+
+    if cmd_line_args.output_directory and not os.path.isdir(cmd_line_args.output_directory):
+        sys.stderr.write(f"Output directory: '{cmd_line_args.output_directory}' does not exist.\n")
+        sys.exit(1)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        print('created temporary directory', tmpdirname)
+
+        binary_name_to_location_map = {}
+        binary_deps = {}
+
+        ldd_filename_path = target_binary
+        binary_key_name = os.path.basename(target_binary)
+        if platform == "Windows" and target_binary.endswith(".ofx"):
+            # Need to make a copy of the plugin and rename it to have a dll extension so ldd
+            # works properly.
+            new_filename = os.path.splitext(os.path.basename(target_binary))[0] + ".dll"
+            ldd_filename_path = os.path.join(tmpdirname,new_filename)
+            shutil.copyfile(target_binary, ldd_filename_path)
+
+        binary_deps = {}
+        deps_remaining = set()
+
+        binary_name_to_location_map[binary_key_name] = ldd_filename_path
+        deps_remaining.add(binary_key_name)
+
+        deps_visited = set()
+        missing_deps = {}
+        while len(deps_remaining) > 0:
+            x = deps_remaining.pop()
+
+            if x in deps_visited:
+                continue
+            deps_visited.add(x)
+
+            x_location = binary_name_to_location_map[x]
+
+            if not should_follow_dep(platform, x, x_location):
+                binary_deps[x] = []
+                continue
+
+            print(f"Finding dependencies for {x}")
+            search_directories.append(os.path.dirname(x_location))
+            (dep_info_list, new_missing_deps) = get_deps_for_binary(platform, x_location, search_directories)
+            search_directories.pop()
+            deps_for_this_library = set()
+            for (dep_name, dep_location) in dep_info_list:
+                deps_for_this_library.add(dep_name)
+
+                if dep_name not in binary_name_to_location_map:
+                    binary_name_to_location_map[dep_name] = dep_location
+                elif not is_valid_lib_path(platform, binary_name_to_location_map[dep_name]):
+                    print(f"A: {binary_name_to_location_map[dep_name]} is not a valid lib path")
+                elif not is_valid_lib_path(platform, dep_location):
+                    print(f"B: {dep_location} is not a file")
+                elif os.path.isfile(dep_location) and not os.path.samefile(binary_name_to_location_map[dep_name], dep_location):
+                    print(f"{dep_name} appears to have more than one location. \
+                     {binary_name_to_location_map[dep_name]} and {dep_location}")
+                    #sys.exit(1)
+
+                if dep_name not in deps_visited:
+                    deps_remaining.add(dep_name)
+
+            for k, v in new_missing_deps.items():
+                dep_set = missing_deps.setdefault(k, set())
+                for dep_path in v:
+                    dep_set.add(dep_path)
+
+            sorted_deps_list = sorted(deps_for_this_library)
+            #for y in deps_list:
+            #    print("\t{}".format(y))
+
+            binary_deps[x] = sorted_deps_list
+
+        json_dict = {
+            "binary_deps": binary_deps,
+            "binary_locations": binary_name_to_location_map,
+        }
+
+
+        full_deps_list = sorted(get_all_deps_for_binary(binary_key_name, json_dict))
+
+        for x in full_deps_list:
+            src = binary_name_to_location_map[x]
+            print(f"{x} : {src}")
+
+            if cmd_line_args.output_directory:
+                shutil.copy(src, cmd_line_args.output_directory)
+
+        if len(missing_deps) > 0:
+            print("Missing dependencies:")
+            for k, v  in missing_deps.items():
+                print(f"\t{k} : {v}")
+
+        if cmd_line_args.json:
+            with open(cmd_line_args.json, "w", encoding='UTF-8') as write_file:
+                json.dump(json_dict, write_file, sort_keys=True, indent=2)
+
+
+        if cmd_line_args.manifest:
+            # Creates a manifest that can be used with a command like the one below to
+            # specify the required DLLs.
+            # mt -nologo -manifest IO.ofx.manifest -outputresource:"IO.ofx;2"
+            manifest = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+            manifest += '<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">\n'
+            manifest += f'  <assemblyIdentity name="{ os.path.basename(target_binary)}" version="1.0.0.0" type="win32" processorArchitecture="amd64"/>\n'
+
+            for x in full_deps_list:
+                manifest += f'  <file name="{x}"></file>\n'
+            manifest += '</assembly>'
+
+            with open(cmd_line_args.manifest, "w", encoding='UTF-8') as write_file:
+                write_file.write(manifest)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Minimal fixes to get Natron and natron-python binaries running.
- Created natron_installer package to organize files similar to the 2.5.0 installers
- Made necessary rpath and installer_name fixes to get Natron to start up on Windows, Ubuntu, and MacOS (ARM & x86_64)
- Setup minimal python environment so natron-python runs
- Added placeholder code to include Natron OCIO configs
- Included Misc.ofx & CImg.ofx plugins to verify plugin loading and provide a way to start verifying functionality.
- Created find_deps.py script that provides a way to collect and analyse shared lib dependencies.