### PR TITLE
Update modules/conancenter ref

### DIFF
--- a/.github/workflows/build_conan_caches.yml
+++ b/.github/workflows/build_conan_caches.yml
@@ -107,10 +107,15 @@ jobs:
           conan config install -t dir config
 
 
-      - name: Download msys2 package from conan-center-index
+      - name: Download Minimal Windows packages from conan-center-index
         if: runner.os == 'Windows'
         run: |
           conan download -r conancenter "msys2/cci.latest"
+
+      - name: Download Minimal Linux packages from conan-center-index
+        if: runner.os == 'Linux'
+        run: |
+          conan download -r conancenter "gnu-config/cci.20210814"
 
       - name: Add Natron specific Conan remotes
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             libxcb-dri3-dev libxcb-cursor-dev libxcb-dri2-0-dev libxcb-dri3-dev \
             libxcb-present-dev libxcb-composite0-dev libxcb-ewmh-dev libxcb-res0-dev \
             libxcb-util-dev libxcb-util0-dev libxkbfile-dev uuid-dev \
-            libegl-dev libwayland-dev libwayland-client0 libwayland-egl1
+            libegl-dev
 
       - name: Install Python
         uses: actions/setup-python@v5
@@ -62,10 +62,9 @@ jobs:
 
       - name: Add Natron specific Conan remotes
         run: |
-          conan remote remove conancenter
+          conan remote disable conancenter
           conan remote add natron_recipes ${{ github.workspace }}
           conan remote add natron_conancenter ${{ github.workspace }}/modules/conan-center-index
-          conan remote add conancenter https://center2.conan.io
 
       - name: Build openfx-misc
         run: |
@@ -152,10 +151,9 @@ jobs:
 
       - name: Add Natron specific Conan remotes
         run: |
-          conan remote remove conancenter
+          conan remote disable conancenter
           conan remote add natron_recipes ${{ github.workspace }}
           conan remote add natron_conancenter ${{ github.workspace }}/modules/conan-center-index
-          conan remote add conancenter https://center2.conan.io
 
       - name: Build openfx-misc
         run: |
@@ -234,10 +232,9 @@ jobs:
 
       - name: Add Natron specific Conan remotes
         run: |
-          conan remote remove conancenter
+          conan remote disable conancenter
           conan remote add natron_recipes ${{ github.workspace }}
           conan remote add natron_conancenter ${{ github.workspace }}/modules/conan-center-index
-          conan remote add conancenter https://center2.conan.io
 
       - name: Build openfx-misc
         run: |
@@ -322,10 +319,9 @@ jobs:
 
       - name: Add Natron specific Conan remotes
         run: |
-          conan remote remove conancenter
+          conan remote disable conancenter
           conan remote add natron_recipes ${{ github.workspace }}
           conan remote add natron_conancenter ${{ github.workspace }}/modules/conan-center-index
-          conan remote add conancenter https://center2.conan.io
 
       - name: Build openfx-misc
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@
 *.exe
 *.out
 *.app
+
+# Conan build files
+conanbuild*.sh
+conanrun*.sh
+deactivate*conan*.sh

--- a/recipes/natron/all/conanfile.py
+++ b/recipes/natron/all/conanfile.py
@@ -34,10 +34,13 @@ class natronRecipe(ConanFile):
         self.requires("expat/2.6.2")
         self.requires("boost/1.84.0")
         self.requires("cairo/1.18.0")
-        self.requires("qt/5.15.14")
+        self.requires("qt/5.15.16")
         self.requires("glog/0.6.0")
         self.requires("ceres-solver/1.14.0")
         self.requires("cpython/3.10.14")
+
+        if self.settings.os == "Linux":
+            self.requires("wayland/1.22.0")
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -86,3 +89,6 @@ class natronRecipe(ConanFile):
 
     def package_info(self):
         self.cpp_info.requires = ["qt::qt", "cpython::cpython", "expat::expat", "boost::boost", "cairo::cairo", "glog::glog", "ceres-solver::ceres-solver"]
+
+        if self.settings.os == "Linux":
+            self.cpp_info.requires += ["wayland::wayland"]

--- a/recipes/natron/all/patches/conan_build_changes.patch
+++ b/recipes/natron/all/patches/conan_build_changes.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 48dd73e..ea15ff8 100644
+index 48dd73e..3505db4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -59,11 +59,11 @@ if(WIN32)
@@ -55,8 +55,12 @@ index 48dd73e..ea15ff8 100644
  
  #Since in Natron and OpenFX all strings are supposed UTF-8 and that the constructor
  #for QString(const char*) assumes ASCII strings, we may run into troubles
-@@ -137,6 +137,7 @@ if(UNIX AND NOT APPLE)
-     find_package(Wayland COMPONENTS Client Egl)
+@@ -134,9 +134,10 @@ if(UNIX AND NOT APPLE)
+     find_package(ECM NO_MODULE)
+     set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${CMAKE_MODULE_PATH})
+     find_package(X11 REQUIRED)
+-    find_package(Wayland COMPONENTS Client Egl)
++    find_package(wayland COMPONENTS wayland-client wayland-egl)
  elseif(APPLE)
      enable_language(OBJCXX)
 +    find_package(OPENGL)
@@ -109,7 +113,7 @@ index 9174556..a1af7d1 100644
  
  void
 diff --git a/Engine/CMakeLists.txt b/Engine/CMakeLists.txt
-index 576f7b2..bc99c3f 100644
+index 576f7b2..29e9e1c 100644
 --- a/Engine/CMakeLists.txt
 +++ b/Engine/CMakeLists.txt
 @@ -17,9 +17,8 @@
@@ -124,22 +128,18 @@ index 576f7b2..bc99c3f 100644
  
  file(GLOB NatronEngine_HEADERS *.h)
  file(GLOB NatronEngine_SOURCES *.cpp)
-@@ -50,7 +49,13 @@ add_custom_command(OUTPUT ${PyEngine_SOURCES}
+@@ -49,8 +48,8 @@ add_custom_command(OUTPUT ${PyEngine_SOURCES}
+ 
  if(UNIX AND NOT APPLE)
      set(XDG_LIBS ${X11_LIBRARIES})
-     if(Wayland_FOUND)
+-    if(Wayland_FOUND)
 -        set(XDG_LIBS Wayland::Client Wayland::Egl ${XDG_LIBS})
-+        if (TARGET wayland::wayland-client)
-+            # Older target names used on Ubuntu 22.04
-+            set(XDG_LIBS wayland::wayland-client wayland::wayland-egl ${XDG_LIBS})
-+        else()
-+            # Newer target names used on Ubuntu 24.04
-+            set(XDG_LIBS Wayland::Client Wayland::Egl ${XDG_LIBS})
-+        endif()
++    if(wayland_FOUND)
++        set(XDG_LIBS wayland::wayland-client wayland::wayland-egl ${XDG_LIBS})
          set(XDG_DEFS __NATRON_WAYLAND__)
      endif()
  endif()
-@@ -58,7 +63,7 @@ endif()
+@@ -58,7 +57,7 @@ endif()
  
  list(APPEND NatronEngine_SOURCES
      ${NatronEngine_SOURCES}
@@ -148,7 +148,7 @@ index 576f7b2..bc99c3f 100644
      ../Global/glad_source.c
      ../Global/FStreamsSupport.cpp
      ../Global/ProcInfo.cpp
-@@ -72,13 +77,13 @@ target_link_libraries(NatronEngine
+@@ -72,13 +71,13 @@ target_link_libraries(NatronEngine
          HostSupport
          Boost::headers
          Boost::serialization
@@ -168,7 +168,7 @@ index 576f7b2..bc99c3f 100644
          Python3::Module
          ${XDG_LIBS}
          ceres
-@@ -93,6 +98,10 @@ if(WIN32)
+@@ -93,6 +92,10 @@ if(WIN32)
      target_link_libraries(NatronEngine PRIVATE mpr)
  endif()
  

--- a/scripts/natron_conan_env.py
+++ b/scripts/natron_conan_env.py
@@ -11,7 +11,7 @@ export_recipe_entries = [
 		RecipeInfo("modules/conan-center-index/recipes/cpython/all", "cpython", "3.10.14", extra_options=["cpython/*:shared=True"]),
 		RecipeInfo("modules/conan-center-index/recipes/sqlite3/all", "sqlite3", "3.46.0"),
 		RecipeInfo("modules/conan-center-index/recipes/tk/all", "tk", "8.6.10"),
-		RecipeInfo("modules/conan-center-index/recipes/qt/5.x.x", "qt", "5.15.14", extra_options=["qt/*:shared=True", "qt/*:qttools=False", "qt/*:qttranslations=False", "qt/*:qtdoc=False", "qt/*:essential_modules=False"]),
+		RecipeInfo("modules/conan-center-index/recipes/qt/5.x.x", "qt", "5.15.16", extra_options=["qt/*:shared=True", "qt/*:qttools=False", "qt/*:qttranslations=False", "qt/*:qtdoc=False", "qt/*:essential_modules=False"]),
 		RecipeInfo("modules/openfx", "openfx", "1.4.0"),
 		RecipeInfo("recipes/clang/all", "clang", "18.1.0"),
 		RecipeInfo("recipes/llvm/all", "llvm", "18.1.0"),


### PR DESCRIPTION
- Update module reference to point to the current commit on the natron_conan_env branch of the acolwell/conan-center-index repo
- Fix linux wayland support.
- Get gnu-config from conancenter remote to avoid download errors during building.
- Disable conan center remote instead of removing it.
- Update qt version that is being used by Natron.